### PR TITLE
Add dere to card full desc

### DIFF
--- a/src/Extensions/CardExtension.cs
+++ b/src/Extensions/CardExtension.cs
@@ -257,6 +257,7 @@ namespace Sanakan.Extensions
                 + $"**Restarty:** {card.RestartCnt}\n"
                 + $"**Pochodzenie:** {card.Source.GetString()}\n"
                 + $"**Moc:** {card.CalculateCardPower().ToString("F")}\n"
+                + $"**Dere:** {card.Dere}\n"
                 + $"**KC:** {card.WhoWantsCount}\n"
                 + $"**Tagi:** {tags}\n"
                 + $"{card.GetStatusIcons()}\n\n";

--- a/src/Extensions/CardExtension.cs
+++ b/src/Extensions/CardExtension.cs
@@ -257,7 +257,7 @@ namespace Sanakan.Extensions
                 + $"**Restarty:** {card.RestartCnt}\n"
                 + $"**Pochodzenie:** {card.Source.GetString()}\n"
                 + $"**Moc:** {card.CalculateCardPower().ToString("F")}\n"
-                + $"**Dere:** {card.Dere}\n"
+                + $"**Charakter:** {card.Dere}\n"
                 + $"**KC:** {card.WhoWantsCount}\n"
                 + $"**Tagi:** {tags}\n"
                 + $"{card.GetStatusIcons()}\n\n";

--- a/src/Sanakan.csproj
+++ b/src/Sanakan.csproj
@@ -7,7 +7,7 @@
     <Copyright>Sniku</Copyright>
     <Product>Sanakan</Product>
     <Authors>Sniku</Authors>
-    <Version>1.3.25.16</Version>
+    <Version>1.3.25.17</Version>
     <RootNamespace>Sanakan</RootNamespace>
     <StartupObject>Sanakan.Sanakan</StartupObject>
   </PropertyGroup>


### PR DESCRIPTION
It was only present in s.card-, why? I think it should be in both if it's card's full stats (almost), so..