### PR TITLE
Karma bonus for mass release/destroy

### DIFF
--- a/src/Sanakan.csproj
+++ b/src/Sanakan.csproj
@@ -7,7 +7,7 @@
     <Copyright>Sniku</Copyright>
     <Product>Sanakan</Product>
     <Authors>Sniku</Authors>
-    <Version>1.3.26.20</Version>
+    <Version>1.3.26.21</Version>
     <RootNamespace>Sanakan</RootNamespace>
     <StartupObject>Sanakan.Sanakan</StartupObject>
   </PropertyGroup>

--- a/src/Services/PocketWaifu/Waifu.cs
+++ b/src/Services/PocketWaifu/Waifu.cs
@@ -2033,14 +2033,28 @@ namespace Sanakan.Services.PocketWaifu
                 DeleteCardImageIfExist(card);
             }
 
+            float karmaBonus = 0.0;
+            if (realDiscardedCount > 200)
+                    karmaBonus = 0.1 * 200;
+            else (realDiscardedCount >= 50)
+                    karmaBonus = 0.1 * realDiscardedCount;
+
+            if (release)
+                user.GameDeck.Karma += karmaBonus;
+            else
+                user.GameDeck.Karma -= karmaBonus;
+
             string actionStr = release ? "uwolni" : "zniszczy";
+            string bonusStr = release ? "wypuszczenie żonek" : "waifbójstwo";
 
             if (ignored.Count == cardsForDiscarding.Count)
                 return ExecutionResult.FromError($"nie udało się {actionStr}ć żadnej karty, najpewniej znajdują się one w klatce lub są oznaczone jako ulubione.");
 
             var response = new StringBuilder().Append($"{actionStr}ł ");
             response.Append(realDiscardedCount > 1 ? $"{realDiscardedCount} kart" : $"kartę: {cardsForDiscarding.First().GetString(false, false, true)}");
-
+            if (karmaBonus != 0)
+                response.Append($"\nZa masowe {bonusStr} otrzymałeś bonus do karmy.");
+                
             if (ignored.Any())
                 response.Append($"\n\n ❗ Nie udało się {actionStr}ć {ignored.Count} kart!");
 


### PR DESCRIPTION
A small bonus for mas destroying or releasing cards (10%) above 50 cards destroyed, upper limit is 200. It's not much, but it would be nice.